### PR TITLE
fix ghost.component.theme.scss

### DIFF
--- a/projects/ngx-ghosts/src/lib/ghost/ghost.component.theme.scss
+++ b/projects/ngx-ghosts/src/lib/ghost/ghost.component.theme.scss
@@ -14,7 +14,9 @@
     &::before {
       background-color: $ghost-base-color;
     }
-
+  }
+  
+  .ghost {
     &__glow {
       background: linear-gradient(
         to right,

--- a/projects/ngx-ghosts/src/lib/ghost/ghost.component.theme.scss
+++ b/projects/ngx-ghosts/src/lib/ghost/ghost.component.theme.scss
@@ -10,7 +10,7 @@
 
   $ghost-glow-animation-id: unique-id();
 
-  .ghost {
+  &.ghost {
     &::before {
       background-color: $ghost-base-color;
     }


### PR DESCRIPTION
fix the theming, so that a theme e.g. `.my-theme` can also override `.ghost::before`
currently the resulting css was 
```
.my-theme .ghost::before {}
```
now it's like intended
```
.my-theme.ghost::before {}
```