### PR TITLE
fix: do not show image until loaded

### DIFF
--- a/libs/ngx-ghosts/src/lib/ghost-image-wrapper/ghost-image-wrapper.component.ts
+++ b/libs/ngx-ghosts/src/lib/ghost-image-wrapper/ghost-image-wrapper.component.ts
@@ -8,11 +8,10 @@ import {
   HostBinding,
   OnDestroy,
   Output,
-  ViewEncapsulation,
+  ViewEncapsulation
 } from '@angular/core';
 import { BehaviorSubject, of, ReplaySubject, timer } from 'rxjs';
 import {
-  delay,
   filter,
   map,
   pairwise,
@@ -20,7 +19,7 @@ import {
   switchMap,
   take,
   takeUntil,
-  tap,
+  tap
 } from 'rxjs/operators';
 import { GhostImageState } from './ghost-image-state';
 import { GhostImageDirective } from './ghost-image.directive';
@@ -63,7 +62,7 @@ export class GhostImageWrapperComponent implements AfterViewInit, OnDestroy {
     map((state) => ['initial', 'loading', 'transitioning'].includes(state))
   );
   imageActive$ = this.state$.pipe(
-    map((state) => ['loading', 'transitioning', 'loaded'].includes(state))
+    map((state) => ['transitioning', 'loaded'].includes(state))
   );
 
   constructor(private elementRef: ElementRef<HTMLElement>) {}


### PR DESCRIPTION
issue: image and loader are shown simultaneously during load
<img width="278" alt="Bildschirmfoto 2021-11-29 um 17 24 05" src="https://user-images.githubusercontent.com/9818404/143915586-14d1bd42-7220-4f8c-ab8f-807780b55cb4.png">
