### PR TITLE
fix: non breaking space in :before

### DIFF
--- a/libs/ngx-ghosts/src/lib/ghost/ghost.component.scss
+++ b/libs/ngx-ghosts/src/lib/ghost/ghost.component.scss
@@ -7,7 +7,7 @@
   color: rgba(0, 0, 0, 0);
 
   &::before {
-    content: '&nbsp;';
+    content: '\a0';
     position: absolute;
     left: 0;
     right: 0;


### PR DESCRIPTION
In CSS you need to use a Unicode escape sequence for such characters, which is based on the hexadecimal value of the code point of a character. Which for a non breaking space is `a0`.
Good explanation see https://stackoverflow.com/a/8595802.

# how to test *before* vs *after*
set `color: #000` on `.ghost:before`